### PR TITLE
Updates for Meteor 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,24 @@
 
 ```
 App.icons({
-  "iphone": "resources/icons/iphone.png", // 60x60
   "iphone_2x": "resources/icons/iphone_2x.png", // 120x120
   "iphone_3x": "resources/icons/iphone_3x.png", // 180x180
   "ipad": "resources/icons/ipad.png", // 76x76
   "ipad_2x": "resources/icons/ipad_2x.png", // 152x152
-  'android_ldpi': "resources/icons/android_ldpi.png", // 36x36
-  'android_mdpi': "resources/icons/android_mdpi.png", // 48x48
-  'android_hdpi': "resources/icons/android_hdpi.png", // 72x72
-  'android_xhdpi': "resources/icons/android_xhdpi.png" // 96x96
+  "ipad_pro": "resources/icons/ipad_pro.png", // 167x167
+  "ios_settings": "resources/icons/ios_settings.png", // 29x29
+  "ios_settings_2x": "resources/icons/ios_settings_2x.png", // 58x58
+  "ios_settings_3x": "resources/icons/ios_settings_3x.png", // 87x87
+  "ios_spotlight": "resources/icons/ios_spotlight", // 40x40
+  "ios_spotlight_2x": "resources/icons/ios_spotlight_2x", // 80x80
+  "android_mdpi": "resources/icons/android_mdpi.png", // 48x48
+  "android_hdpi": "resources/icons/android_hdpi.png", // 72x72
+  "android_xhdpi": "resources/icons/android_xhdpi.png", // 96x96
+  "android_xxhdpi": "resources/icons/android_xxhdpi.png", // 144x144
+  "android_xxxhdpi": "resources/icons/android_xxxhdpi.png" // 192x192
 });
 
 App.launchScreens({
-  "iphone": "resources/splashes/iphone.png", // 320x245
   "iphone_2x": "resources/splashes/iphone_2x.png", // 640x490
   "iphone5": "resources/splashes/iphone5.png", // 640x1136
   "iphone6": "resources/splashes/iphone6.png", // 750x1334
@@ -41,18 +46,18 @@ App.launchScreens({
   "ipad_portrait_2x": "resources/splashes/ipad_portrait_2x.png", // 1536x2048
   "ipad_landscape": "resources/splashes/ipad_landscape.png", // 1024x768
   "ipad_landscape_2x": "resources/splashes/ipad_landscape_2x.png", // 2048x1536
-  "android_ldpi_portrait": "resources/splashes/android_ldpi_portrait.png", // 200x320
-  "android_ldpi_landscape": "resources/splashes/android_ldpi_landscape.png", // 320x200
   "android_mdpi_portrait": "resources/splashes/android_mdpi_portrait.png", // 320x480
   "android_mdpi_landscape": "resources/splashes/android_mdpi_landscape.png", // 480x320
   "android_hdpi_portrait": "resources/splashes/android_hdpi_portrait.png", // 480x800
   "android_hdpi_landscape": "resources/splashes/android_hdpi_landscape.png", // 800x480
   "android_xhdpi_portrait": "resources/splashes/android_xhdpi_portrait.png", // 720x1280
-  "android_xhdpi_landscape": "resources/splashes/android_xhdpi_landscape.png" // 1280x720
+  "android_xhdpi_landscape": "resources/splashes/android_xhdpi_landscape.png", // 1280x720
+  "android_xxhdpi_portrait": "resources/splashes/android_xxhdpi_portrait.png", // 1080x1440
+  "android_xxhdpi_landscape": "resources/splashes/android_xxhdpi_landscape.png" // 1440x1080
 })
 ```
 
-Sizes thanks to https://gist.github.com/jperl/f8c395b9f0f1056ad890
+Sizes thanks to https://github.com/meteor/meteor/blob/release-1.3/tools/cordova/builder.js
 
 ## Notes
 

--- a/meteor-assets.js
+++ b/meteor-assets.js
@@ -2,19 +2,24 @@ var fs = require('fs'),
     gm = require('gm').subClass({imageMagick: true});
 
 var icons = [
-  {name:"iphone", size: "60x60"},
   {name:"iphone_2x", size: "120x120"},
   {name: "iphone_3x", size: "180x180"},
   {name: "ipad", size: "76x76"},
   {name: "ipad_2x", size: "152x152"},
-  {name: "android_ldpi", size: "36x36"},
+  {name: "ipad_pro", size: "167x167"},
+  {name: "ios_settings", size: "29x29"},
+  {name: "ios_settings_2x", size: "58x58"},
+  {name: "ios_settings_3x", size: "87x87"},
+  {name: "ios_spotlight", size: "40x40"},
+  {name: "ios_spotlight_2x", size: "80x80"},
   {name: "android_mdpi", size: "48x48"},
   {name: "android_hdpi", size: "72x72"},
-  {name: "android_xhdpi", size: "96x96"}
+  {name: "android_xhdpi", size: "96x96"},
+  {name: "android_xxhdpi", size: "144x144"},
+  {name: "android_xxxhdpi", size: "192x192"}
 ]
 
 var splashes = [
-  {"name":"iphone","size":"320x480"},
   {"name":"iphone_2x","size":"640x960"},
   {"name":"iphone5","size":"640x1136"},
   {"name":"iphone6","size":"750x1334"},
@@ -24,16 +29,16 @@ var splashes = [
   {"name":"ipad_portrait_2x","size":"1536x2048"},
   {"name":"ipad_landscape","size":"1024x768"},
   {"name":"ipad_landscape_2x","size":"2048x1536"},
-  {"name":"android_ldpi_portrait","size":"200x320"},
   {"name":"android_ldpi_landscape","size":"320x200"},
   {"name":"android_mdpi_portrait","size":"320x480"},
   {"name":"android_mdpi_landscape","size":"480x320"},
   {"name":"android_hdpi_portrait","size":"480x800"},
   {"name":"android_hdpi_landscape","size":"800x480"},
   {"name":"android_xhdpi_portrait","size":"720x1280"},
-  {"name":"android_xhdpi_landscape","size":"1280x720"}
+  {"name":"android_xhdpi_landscape","size":"1280x720"},
+  {"name":"android_xxhdpi_portrait","size":"1080x1440"},
+  {"name":"android_xxhdpi_landscape","size":"1440x1080"}
  ]
-
 
 function getSize(image) {
   var sizes = image.size.split('x');


### PR DESCRIPTION
I believe the new version of Cordova bundled with Meteor 1.3 supports these icon and splash screen assets as per https://github.com/meteor/meteor/blob/release-1.3/tools/cordova/builder.js. 
